### PR TITLE
add github issue plan workflow skills

### DIFF
--- a/.claude/skills/import-issue/SKILL.md
+++ b/.claude/skills/import-issue/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: import-issue
+description: Import a GitHub issue as a local Claude Code plan file and enter plan mode. Developer-side skill — run from your own Claude Code CLI session, not the agent. Fetches the Implementation Plan section from the issue, writes a local plan file with YAML front matter, and enters plan mode for review before implementation.
+---
+
+# import-issue
+
+Fetches a GitHub issue and converts it into a local Claude Code plan file, then enters plan mode so you can review and approve before implementation begins.
+
+Run this from your own Claude Code CLI session. Do not run this from the nanoclaw agent.
+
+## Step 1: Get issue details
+
+Ask the user (via AskUserQuestion if not provided):
+- Issue number or full URL?
+- Repo (`owner/repo`)? If a full URL was given, parse it from there.
+
+Fetch the issue:
+```bash
+gh issue view <number> --repo <owner/repo> --json title,body,comments,labels,assignees,milestone,number,url
+```
+
+## Step 2: Check for unresolved comments
+
+Read the `comments` array from the JSON output. If there are comments, check whether any appear to contain unresolved feedback or decisions that have not been folded into the issue body.
+
+Signs of unresolved comments:
+- Comments posted after the last body edit
+- Comments that propose changes, ask questions, or suggest alternatives
+- Comments that contain words like "should we", "what about", "I think", "actually"
+
+If unresolved comments are found, use AskUserQuestion:
+
+> There are [N] comments on this issue. Some may contain feedback not yet reflected in the plan body. Would you like to include a summary of the comments in the imported plan?
+> - Yes — include a Discussion Summary section
+> - No — import the plan body only
+
+## Step 3: Parse the plan body
+
+The issue body uses section headings to delimit content:
+
+- Everything before `## Implementation Plan` is context/background
+- `## Implementation Plan` and below is the actionable plan
+- `## Post-Implementation Notes` (if present) contains post-merge errata
+
+Extract:
+- Full body (for context)
+- The `## Implementation Plan` section (primary input to plan mode)
+- The `## Post-Implementation Notes` section if present (include as reference)
+
+If the issue body has no `## Implementation Plan` heading, treat the entire body as the plan and note this to the user.
+
+## Step 4: Determine the output path
+
+Default path: `plans/issue-<number>.md` relative to the repo root.
+
+If a `plans/` directory does not exist, create it.
+
+If a file already exists at that path:
+- Show a diff between the existing file and the incoming issue content
+- Use AskUserQuestion to ask whether to overwrite, merge, or abort
+- Default: issue is source of truth, overwrite — but require confirmation
+
+## Step 5: Write the local plan file
+
+Write the file with YAML front matter:
+
+```markdown
+---
+issue: <number>
+repo: <owner/repo>
+url: <issue url>
+title: <issue title>
+status: <label if present, else "draft">
+imported: <today's date YYYY-MM-DD>
+---
+
+## Context
+
+[Everything from the issue body before ## Implementation Plan]
+
+## Implementation Plan
+
+[The ## Implementation Plan section from the issue]
+
+## Post-Implementation Notes
+
+[The ## Post-Implementation Notes section, if present]
+
+## Discussion Summary
+
+[If user requested: concise summary of issue comments, attributed by author]
+```
+
+## Step 6: Enter plan mode
+
+After writing the file, tell the user:
+
+> Plan imported to `plans/issue-<number>.md`. Entering plan mode — review the plan below and approve to begin implementation.
+
+Then enter plan mode using the plan file. Present the Implementation Plan section for review. Do not begin implementation until the user approves.
+
+## Step 7: On approval
+
+After plan mode approval, suggest:
+- Create a feature branch: `git checkout -b feature/issue-<number>-<short-description>`
+- Reference the issue in commits: `gh issue develop <number> --repo <owner/repo>` links commits to the issue automatically
+- When done, open a PR that closes the issue: `gh pr create --title "..." --body "Closes #<number>"`

--- a/.claude/skills/publish-plan/SKILL.md
+++ b/.claude/skills/publish-plan/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: publish-plan
+description: Publish a local plan file or in-chat plan to a GitHub issue. Creates a new issue or updates an existing one. Agent-side skill designed to run under a Planning PAT (Contents read, PR read, Issues read+write). Also runnable from a developer's Claude Code CLI session.
+---
+
+# publish-plan
+
+Publishes a plan to a GitHub issue. Use this when a plan has been drafted in chat or as a local markdown file and is ready to be shared with the team on GitHub.
+
+## Safety note
+
+This skill is designed to run under a Planning PAT with Issues read+write scope only. If running under full personal GitHub credentials, you MUST prompt for explicit confirmation before every `gh` command that writes anything, showing the exact command to be run. Never batch write operations without a confirmation step between them.
+
+## Step 1: Determine the source
+
+Ask the user (via AskUserQuestion if context is ambiguous):
+
+- Is the plan in the current chat conversation, or in a local file?
+- If a local file: what is the path?
+- Should this create a new issue, or update an existing one?
+  - If updating: what is the issue number?
+- What repo should the issue be created in? (e.g. `owner/repo`)
+  - If GH_TOKEN is set, check: `gh repo list --limit 5` to suggest likely repos.
+
+## Step 2: Compose the issue body
+
+### If plan is in chat
+
+Synthesize the current plan from the conversation into a structured markdown document using the standard plan file format:
+
+```
+---
+status: draft
+---
+
+## Context
+
+[Background, goals, constraints discussed in chat]
+
+## Implementation Plan
+
+[Actionable steps, file changes, approach decisions]
+```
+
+Do not include chat back-and-forth, exploratory discussion, or alternatives that were ruled out. The issue body should be the clean, decided plan only.
+
+### If plan is a local file
+
+Read the file. If it has YAML front matter, preserve it (stripping local-only fields like `imported`). Use the file content as-is.
+
+## Step 3: Publish to GitHub
+
+### Creating a new issue
+
+Run:
+```bash
+gh issue create --repo <owner/repo> --title "<title>" --body "<body>"
+```
+
+If running under full credentials (not a Planning PAT), show the command and ask for confirmation before running.
+
+After creation, print the issue URL.
+
+### Updating an existing issue
+
+First, show the user the current issue body:
+```bash
+gh issue view <number> --repo <owner/repo>
+```
+
+Then show what the new body will be and ask for confirmation before overwriting.
+
+Run:
+```bash
+gh issue edit <number> --repo <owner/repo> --body "<new body>"
+```
+
+If running under full credentials, require explicit confirmation before running.
+
+## Step 4: Update local file (if applicable)
+
+If the plan came from a local file, update its YAML front matter to record the issue number and repo:
+
+```yaml
+---
+issue: <number>
+repo: <owner/repo>
+status: draft
+published: <today's date>
+---
+```
+
+## Step 5: Confirm
+
+Tell the user the issue URL and current status label. Suggest next steps:
+- Share the issue URL with teammates for review
+- Use `update-plan --from=comments` to pull in feedback from issue comments
+- Add a `ready-for-dev` label when the plan is finalized: `gh issue edit <number> --repo <owner/repo> --add-label ready-for-dev`

--- a/.claude/skills/update-plan/SKILL.md
+++ b/.claude/skills/update-plan/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: update-plan
+description: Update a GitHub issue plan from one of four sources — issue comments, chat conversation, implementation outcome, or a local plan file. Agent-side variants (--from=comments, --from=chat) are designed for the Planning PAT. Developer-side variants (--from=implementation, --from=file) require full gh CLI access.
+---
+
+# update-plan
+
+Updates a GitHub issue body to reflect new information. The source of the update determines which variant to use.
+
+## Safety note
+
+The `--from=comments` and `--from=chat` variants are designed to run under a Planning PAT with Issues read+write scope. If running under full personal GitHub credentials, prompt for explicit confirmation before every `gh` command that writes anything.
+
+## Determine the variant
+
+If the user did not specify a variant, ask via AskUserQuestion:
+
+> What is the source of the update?
+> - Comments — synthesize new issue comments into the plan body
+> - Chat — update the plan based on decisions made in this conversation
+> - Implementation — append post-implementation notes after a PR is merged
+> - File — overwrite the issue body from a local plan file
+
+---
+
+## Variant: --from=comments
+
+Use when new comments have been added to the issue and their content should be folded into the plan body.
+
+### Step 1: Fetch current state
+
+```bash
+gh issue view <number> --repo <owner/repo> --json body,comments,updatedAt
+```
+
+### Step 2: Identify new comments
+
+Find comments posted after the last body edit (compare timestamps). If all comments are old, tell the user there is nothing new to fold in.
+
+### Step 3: Synthesize
+
+Read the new comments. For each comment:
+- If it proposes a change to the plan: incorporate it into the relevant section of the body
+- If it asks a question that has been answered: fold the answer into the plan
+- If it is a +1/acknowledgment/emoji: ignore
+
+Do not include the raw comment text in the body. Synthesize cleanly into the existing plan structure.
+
+### Step 4: Show diff and confirm
+
+Show the user what will change in the issue body. Ask for confirmation before writing.
+
+### Step 5: Update
+
+```bash
+gh issue edit <number> --repo <owner/repo> --body "<updated body>"
+```
+
+---
+
+## Variant: --from=chat
+
+Use when decisions have been made in the current chat conversation that should be reflected in the issue.
+
+### Step 1: Fetch current issue body
+
+```bash
+gh issue view <number> --repo <owner/repo> --json body,number,title,url
+```
+
+### Step 2: Identify what changed
+
+Review the current conversation. Identify:
+- Decisions made that are not yet in the issue body
+- Corrections to the existing plan
+- New open questions that should be captured
+- Anything explicitly ruled out that should be noted
+
+Do not include exploratory discussion or alternatives that were rejected. Only include decided, actionable content.
+
+### Step 3: Show diff and confirm
+
+Show the user a summary of what will change and the new body. Ask for confirmation.
+
+### Step 4: Update
+
+```bash
+gh issue edit <number> --repo <owner/repo> --body "<updated body>"
+```
+
+If running under full credentials, show the exact command and require confirmation before running.
+
+---
+
+## Variant: --from=implementation
+
+Use after a PR has been merged to append post-implementation notes documenting what diverged from the plan.
+
+Run from your Claude Code CLI session (requires full gh CLI access to read PRs).
+
+### Step 1: Gather inputs
+
+Ask the user (via AskUserQuestion if not provided):
+- PR number or URL that implemented this issue
+- Issue number and repo
+- Any specific divergences or discoveries to capture
+
+### Step 2: Read the PR
+
+```bash
+gh pr view <pr-number> --repo <owner/repo> --json title,body,mergedAt,files
+gh pr diff <pr-number> --repo <owner/repo>
+```
+
+### Step 3: Compare plan to implementation
+
+Read the local plan file (if available at `plans/issue-<number>.md`) or fetch the issue body. Compare the `## Implementation Plan` section against the actual PR diff and files changed.
+
+Identify:
+- Steps in the plan that were implemented differently than specified
+- Files changed that were not mentioned in the plan
+- Files mentioned in the plan that were not changed
+- Discoveries made during implementation (unexpected dependencies, edge cases, etc.)
+- Test results and any failures that required plan changes
+
+### Step 4: Compose post-implementation notes
+
+Write a `## Post-Implementation Notes` section:
+
+```markdown
+## Post-Implementation Notes
+
+Merged: PR #<number> on <date>
+
+### What diverged from the plan
+
+[List specific plan steps that were implemented differently, and why]
+
+### Unexpected discoveries
+
+[Edge cases, dependencies, or constraints found during implementation]
+
+### Test results
+
+[Summary of what was tested and outcome]
+```
+
+If nothing diverged and there are no discoveries, write a brief confirmation: "Implemented as specified. No divergences."
+
+### Step 5: Update the issue
+
+Show the user the proposed post-implementation notes section and ask for confirmation. Then append it to the issue body:
+
+```bash
+gh issue edit <number> --repo <owner/repo> --body "<existing body + new section>"
+```
+
+Optionally close the issue:
+```bash
+gh issue close <number> --repo <owner/repo> --comment "Implemented in PR #<pr-number>"
+```
+
+---
+
+## Variant: --from=file
+
+Use when a local plan file has been edited and the changes should be pushed back to the GitHub issue.
+
+### Step 1: Read the local file
+
+Read the plan file (default: `plans/issue-<number>.md`). Extract:
+- YAML front matter (issue number, repo)
+- Full body content (excluding front matter)
+
+### Step 2: Show diff
+
+Fetch the current issue body:
+```bash
+gh issue view <number> --repo <owner/repo> --json body
+```
+
+Show a diff between the current issue body and the local file content.
+
+### Step 3: Confirm and update
+
+Ask for confirmation, then update:
+```bash
+gh issue edit <number> --repo <owner/repo> --body "<file content without front matter>"
+```
+
+If running under full credentials, require explicit confirmation before running.

--- a/.claude/skills/validate-plan/SKILL.md
+++ b/.claude/skills/validate-plan/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: validate-plan
+description: Compare a GitHub issue plan against an actual implementation (PR diff or current codebase) and flag gaps, undocumented divergences, or a stale plan. Run from your Claude Code CLI session after implementation is complete. Prompts you to run update-plan if divergences are found.
+---
+
+# validate-plan
+
+Reads a GitHub issue plan and compares it against what was actually built. Flags gaps and divergences, then prompts to run `update-plan --from=implementation` if the plan is stale.
+
+Run this from your Claude Code CLI session after a PR is merged or implementation is complete. Do not run from the nanoclaw agent.
+
+## Step 1: Gather inputs
+
+Ask the user (via AskUserQuestion if not provided):
+- Issue number and repo
+- What to compare against:
+  - A merged PR (provide PR number)
+  - The current working directory (compare plan against files on disk)
+  - A specific branch
+
+## Step 2: Fetch the plan
+
+```bash
+gh issue view <number> --repo <owner/repo> --json title,body,number,url
+```
+
+Extract the `## Implementation Plan` section. If no such heading exists, use the full body.
+
+Also check for a local plan file at `plans/issue-<number>.md` — if it exists and is newer than the issue body, note that the local file may have additional context.
+
+## Step 3: Fetch the implementation
+
+### If comparing against a PR:
+
+```bash
+gh pr view <pr-number> --repo <owner/repo> --json title,body,mergedAt,files,commits
+gh pr diff <pr-number> --repo <owner/repo>
+```
+
+### If comparing against the working directory:
+
+Read the relevant files identified in the plan. Use `git log --oneline -20` and `git diff main...HEAD` to understand recent changes.
+
+### If comparing against a branch:
+
+```bash
+git diff main...<branch> --name-only
+git diff main...<branch>
+```
+
+## Step 4: Compare plan to implementation
+
+For each item in the `## Implementation Plan`:
+
+- **Implemented as specified**: file was changed, approach matches — mark OK
+- **Implemented differently**: file was changed but approach differs from plan — flag
+- **Not implemented**: plan step not reflected in any changed file — flag
+- **Extra changes**: files changed that are not mentioned in the plan — flag
+
+Also check:
+- Were any plan-specified files NOT touched?
+- Were any files touched that the plan said should not be changed?
+- Does the PR/commit description reference the issue (`Closes #N`, `Fixes #N`)?
+
+## Step 5: Produce a validation report
+
+Output a report in this format:
+
+```
+Plan Validation Report — Issue #<N>: <title>
+
+Compared against: PR #<M> / branch <name> / working directory
+Date: <today>
+
+SUMMARY: <X> items match, <Y> divergences, <Z> unimplemented steps
+
+--- MATCHES ---
+✓ <plan step or file> — implemented as specified
+
+--- DIVERGENCES ---
+✗ <plan step or file>
+  Plan said: <what the plan specified>
+  Actually: <what was found in the diff/files>
+
+--- NOT IMPLEMENTED ---
+? <plan step or file> — no matching changes found
+
+--- EXTRA CHANGES (not in plan) ---
++ <file or area> — changed but not mentioned in plan
+```
+
+## Step 6: Prompt for action
+
+If there are divergences or unimplemented steps, use AskUserQuestion:
+
+> The plan has [N] divergences from the implementation. Would you like to update the issue to reflect what was actually built?
+> - Yes — run update-plan to document divergences
+> - No — leave the issue as-is
+
+If the user selects yes, invoke the `update-plan` skill with `--from=implementation`, passing the issue number, PR number, and the divergences identified in this report.
+
+If the plan matches exactly, confirm:
+> Plan validation passed. The implementation matches the plan. No updates needed.
+
+Optionally suggest closing the issue if it is still open:
+```bash
+gh issue close <number> --repo <owner/repo>
+```


### PR DESCRIPTION
Four new skills for a planning workflow using GitHub issues as the handoff point between agent planning and developer implementation:

- publish-plan: creates or updates a GitHub issue from a local plan file or in-chat plan; designed for Planning PAT (Issues read+write)
- import-issue: fetches an issue and writes a local plan file with YAML front matter, then enters plan mode for developer review
- update-plan: four variants (--from=comments, --from=chat, --from=implementation, --from=file) for keeping the issue body in sync with evolving plans and implementation outcomes
- validate-plan: compares a plan against a PR diff or working directory, flags divergences, and prompts to run update-plan if stale

Closes #1, #2 (rwhaling/nanoclaw)

## Type of Change

- [ ] **Skill** - adds a new skill in `.claude/skills/`
- [ ] **Fix** - bug fix or security fix to source code
- [ ] **Simplification** - reduces or simplifies source code

## Description


## For Skills

- [ ] I have not made any changes to source code
- [ ] My skill contains instructions for Claude to follow (not pre-built code)
- [ ] I tested this skill on a fresh clone
